### PR TITLE
Infinity% traitor chance in lobby fix

### DIFF
--- a/Lua/traitormodutil.lua
+++ b/Lua/traitormodutil.lua
@@ -433,7 +433,7 @@ Traitormod.GetDataInfo = function(client, showWeights)
     if showWeights then
         local maxPoints = 0
         for index, value in pairs(Client.ClientList) do
-            if value.Character and not value.Character.IsDead then
+            if value.Character and not value.Character.IsDead or not Game.RoundStarted then
                 maxPoints = maxPoints + (Traitormod.GetData(value, "Weight") or 0)
             end
         end


### PR DESCRIPTION
In the lobby, if you use the `!points` command, it shows that everyone's chance of becoming a traitor is `Infinity%`. This is because when calculating `maxPoints`, the `GetDataInfo` function filters out all players (clients), since no one has a character.
With this fix, players are not filtered if the round has not yet started